### PR TITLE
Cleanup events and use node.js for static http server

### DIFF
--- a/example/stream/static_server.jsm
+++ b/example/stream/static_server.jsm
@@ -1,0 +1,67 @@
+"use strict";
+
+// This runs a static http server directly off the __dirname folder
+// Usage: node server.jsm <port>
+
+const http = require('http');
+const url = require('url');
+const fs = require('fs');
+const path = require('path');
+const port = process.argv[2] || 9000;
+
+// execute the code from the current directory
+process.chdir(__dirname);
+
+http.createServer(function (req, res) {
+  console.log(`${req.method} ${req.url}`);
+
+  // parse URL
+  const parsedUrl = url.parse(req.url);
+  // extract URL path
+  let pathname = `.${parsedUrl.pathname}`;
+  // based on the URL path, extract the file extention. e.g. .js, .doc, ...
+  const ext = path.parse(pathname).ext || '.html';
+  // maps file extention to MIME typere
+  const map = {
+    '.ico': 'image/x-icon',
+    '.html': 'text/html',
+    '.js': 'text/javascript',
+    '.json': 'application/json',
+    '.css': 'text/css',
+    '.png': 'image/png',
+    '.jpg': 'image/jpeg',
+    '.wav': 'audio/wav',
+    '.mp3': 'audio/mpeg',
+    '.svg': 'image/svg+xml',
+    '.pdf': 'application/pdf',
+    '.doc': 'application/msword'
+  };
+
+  fs.exists(pathname, function (exist) {
+    if(!exist) {
+      // if the file is not found, return 404
+      res.statusCode = 404;
+      res.end(`File ${pathname} not found!`);
+      return;
+    }
+
+    // if is a directory search for index file matching the extention
+    if (fs.statSync(pathname).isDirectory()) pathname += '/index' + ext;
+
+    // read file from file system
+    fs.readFile(pathname, function(err, data){
+      if(err){
+        res.statusCode = 500;
+        res.end(`Error getting the file ${pathname}: ${err}.`);
+      } else {
+        // if the file is found, set Content-type and send data
+        res.setHeader('Content-type', map[ext] || 'text/plain' );
+        res.end(data);
+      }
+    });
+  });
+
+
+}).listen(parseInt(port));
+
+console.log(`Server listening on port ${port}`);

--- a/expect.js
+++ b/expect.js
@@ -3,18 +3,21 @@
 exports.expect = function expect(v) {
   function assert(isEqual, other) {
     if (!isEqual) {
-      throw new Error(
-        "expected " + JSON.stringify(v) + " to equal " + JSON.stringify(other)
-      );
+      const got = JSON.stringify(v);
+      const want = JSON.stringify(other);
+      throw new Error("expected " + got + " to equal " + want);
     }
   }
+
   function equal(other) {
     assert(v === other, other);
   }
+
   function deepEqual(other) {
     if (v === other) {
       return;
     }
+
     assert(!v === !other);
     if (typeof v !== "object" || v === null) {
       assert(false, other);
@@ -26,6 +29,7 @@ exports.expect = function expect(v) {
         expect(v[key]).to.deep.equal(other[key]);
       }
     }
+
     for (let key in other) {
       if (other.hasOwnProperty(key)) {
         expect(v.hasOwnProperty(key)).to.equal(true);

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "nyc mocha *_test.js",
     "coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov",
     "pretty": "find . -name '*.js' | grep -v node_modules | xargs yarn prettier --write",
-    "stream_server": "cd example/stream; python -m SimpleHTTPServer 8081",
+    "stream_server": "node example/stream/static_server.jsm 8081",
     "stream": "yarn webpack -o example/stream/app.dist.js --mode development example/stream/app.js"
   },
   "nyc": {


### PR DESCRIPTION
The events delegation had an adhoc way to deal with events that don't bubble.   That  is cleaned up a bit.

SimpleHTTPServer (python) does not handle control-C well.  Removing the python dependency altogether by migrating to a simple node.js based static http web server.