### PR TITLE
Script to create eslint distributable

### DIFF
--- a/script/eslint_builder.sh
+++ b/script/eslint_builder.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+yarn add rollup --dev
+yarn add @rollup/plugin-node-resolve  --dev
+yarn add @rollup/plugin-commonjs  --dev
+yarn add @rollup/plugin-json --dev
+yarn add eslint --dev
+cat > rollup.config.js <<EOF
+import resolve from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
+import json from '@rollup/plugin-json';
+
+export default {
+  input: '-',
+  shimMissingExports: true,
+  output: {
+    file: 'eslint.js',
+    format: 'cjs',
+    name: 'Boo'
+  },
+  plugins: [
+    resolve({preferBuiltins: true}),
+    commonjs(),
+    json()
+  ],
+}
+EOF
+
+yarn run rollup -c  <<EOF
+import eslint from "eslint";
+import format from "eslint/lib/cli-engine/formatters/compact.js";
+
+function main() {
+  const cli = new (eslint.CLIEngine)({
+    envs: ["es6", "mocha"],
+    useEslintrc: false
+  });
+
+  const report = cli.executeOnFiles(["vdom_test.js"]);
+  console.log(format(report.results));
+}
+
+main();
+
+EOF
+
+rm rollup.config.js
+yarn remove @rollup/plugin-json
+yarn remove @rollup/plugin-node-resolve
+yarn remove @rollup/plugin-commonjs
+yarn remove rollup
+yarn remove eslint


### PR DESCRIPTION
This PR is not meant to  be merged.  

It has a script that when run builds a single file `eslint.js` with no dependencies: `node eslint.js` will effectively run eslint locally.

I suspect we can create a separate repository with a single eslist.js distribution and then use this everywhere (but requires a better config setup than this).

Not sure about this though -- seems somewhat fragile.

@lukebayes 